### PR TITLE
Default empty dict

### DIFF
--- a/drf_custom_viewsets/viewsets.py
+++ b/drf_custom_viewsets/viewsets.py
@@ -2,6 +2,7 @@ from rest_framework.viewsets import ModelViewSet
 
 
 class CustomSerializerViewSet(ModelViewSet):
+    custom_serializer_classes = {}
 
     def get_serializer_class(self):
         """ Return the class to use for serializer w.r.t to the request method."""


### PR DESCRIPTION
Define a default empty dict `custom_serializer_classes = {}`. Two reasons:
- Makes it friendly for code completion.
- Allows `custom_serializer_classes.append(...)`  and similar things, in other mixins for more complex situations.
